### PR TITLE
Check for invalid role alert to display message when profile is null

### DIFF
--- a/php/WordPressPlugin/Actions.php
+++ b/php/WordPressPlugin/Actions.php
@@ -37,11 +37,12 @@ class Actions
 
     public static function notifyInvalidCredentials(): void
     {
-
+        if(PluginConfiguration::isEnabled() && is_null(PluginConfiguration::getApiProfile())) {
             $message = __("Incorrect Token, or Endpoint: Could not load Profile", WordPressPlugin::I18N_NS);
             echo sprintf("<div class=\"notice notice-error\">
                     <p>%s</p>
                 </div>", $message);
+        }
     }
 
     public static function notifyInvalidRole(): void


### PR DESCRIPTION
When a profile is searched for with a new endpoint the first time that the profile is fetched an error is given and the profile is null, which leads to the transient being created, and allowing for the alert that the endpoint or token is invalid. Due to this adding a check in the action to ensure that the profile is truly invalid before displaying the alert stops this false negative from occurring. This fixes #110 . 

The error given is as follows:
`GetProfileRequest.ERROR: Error fetching profile: Invalid Coyote API response for https://staging.coyote.pics/api/v1/profile/, status 401 {"class":"Coyote\\Request\\GetProfileRequest"}`
