### PR TITLE
Instance check for ProfileModel, migrate to v2 ProfileModel when from v1

### DIFF
--- a/php/PluginConfiguration.php
+++ b/php/PluginConfiguration.php
@@ -119,7 +119,10 @@ class PluginConfiguration
             return null;
 
         if (!$profile instanceof ProfileModel)
-            self::setApiProfile(WordPressCoyoteApiClient::getProfile());
+            $profile = WordPressCoyoteApiClient::getProfile();
+
+        if(!is_null($profile))
+            self::setApiProfile($profile);
 
         return $profile;
     }

--- a/php/PluginConfiguration.php
+++ b/php/PluginConfiguration.php
@@ -115,16 +115,13 @@ class PluginConfiguration
      */
     public static function possiblyMigrateApiProfile($profile): ?ProfileModel
     {
-        if(is_null( $profile ))
+        if (is_null($profile))
             return null;
 
-        if( ! $profile instanceof ProfileModel ) {
-            $profile = WordPressCoyoteApiClient::getProfile();
-            self::setApiProfile( $profile );
-        }
+        if (!$profile instanceof ProfileModel)
+            self::setApiProfile(WordPressCoyoteApiClient::getProfile());
 
         return $profile;
-
     }
 
     public static function setApiProfile(ProfileModel $profile): void

--- a/php/PluginConfiguration.php
+++ b/php/PluginConfiguration.php
@@ -106,7 +106,25 @@ class PluginConfiguration
 
     public static function getApiProfile(): ?ProfileModel
     {
-        return get_option('coyote_api_profile', null);
+        return self::possiblyMigrateApiProfile( get_option('coyote_api_profile', null) );
+    }
+
+    /*
+     * Check if ProfileModel is outdated (v1 object)
+     * If so, retrieve v2 model and update the object in the database
+     */
+    public static function possiblyMigrateApiProfile($profile): ?ProfileModel
+    {
+        if(is_null( $profile ))
+            return null;
+
+        if( ! $profile instanceof ProfileModel ) {
+            $profile = WordPressCoyoteApiClient::getProfile();
+            self::setApiProfile( $profile );
+        }
+
+        return $profile;
+
     }
 
     public static function setApiProfile(ProfileModel $profile): void


### PR DESCRIPTION
This addresses #107. When a profile is retrieved, a check is performed to determine whether any stored non-null data is a `ProfileModel`. If not, it gets replaced by a freshly retrieved `ProfileModel`.