### PR TITLE
113 classify api endpoint configuration as advanced setting

### DIFF
--- a/php/Controllers/SettingsController.php
+++ b/php/Controllers/SettingsController.php
@@ -508,7 +508,7 @@ class SettingsController {
 
         /*
          * Register submenu page for Coyote advanced settings
-         * Only when not in standalone mode and a valid profile is set
+         * Only when not in standalone mode
          */
         if (!$this->is_standalone) {
             add_submenu_page(
@@ -610,7 +610,7 @@ class SettingsController {
         );
 
         /*
-         * Check if in standalone, if so return (don't render any fields)
+         * Check if in standalone mode, if so return (don't render any fields)
          * This check can't be placed before the previous add_settings_section (if so no admin page content is rendered)
          */
         if ($this->is_standalone)
@@ -636,8 +636,8 @@ class SettingsController {
         );
 
         /*
-         * Check if profile is set, if not return
-         * This only renders the fields needed to register an API token
+         * Check if profile is set
+         * This renders all Coyote settings fields
          */
         if ($this->profile) {
 
@@ -689,6 +689,11 @@ class SettingsController {
             ['label_for' => 'coyote_api_endpoint']
         );
 
+        /*
+         * Check if profile is set, if not return
+         * If no profile is set, the rendering stops at this point
+         * only the required fields to link to the Coyote API are visible
+         */
         if(!$this->profile)
             return;
 

--- a/php/PluginConfiguration.php
+++ b/php/PluginConfiguration.php
@@ -30,7 +30,8 @@ class PluginConfiguration
 
     public static function getMetum(): ?string
     {
-        return get_option('coyote_api_metum', self::METUM);
+        $metum = get_option('coyote_api_metum', self::METUM);
+        return self::isNonEmptyString( $metum ) ? $metum : self::METUM;
     }
 
     public static function setApiOrganizationId(string $id): void
@@ -76,12 +77,12 @@ class PluginConfiguration
 
     public static function hasFiltersEnabled(): bool
     {
-        return get_option('coyote_filters_enabled', false);
+        return !!get_option('coyote_filters_enabled', false);
     }
 
     public static function hasUpdatesEnabled(): bool
     {
-        return get_option('coyote_updates_enabled', false);
+        return !!get_option('coyote_updates_enabled', false);
     }
 
     public static function hasStoredApiProfile(): bool
@@ -91,7 +92,7 @@ class PluginConfiguration
 
     public static function isInstalled(): bool
     {
-        return get_option('coyote_plugin_is_installed', false);
+        return !!get_option('coyote_plugin_is_installed', false);
     }
 
     /** @return int|bool */
@@ -167,7 +168,7 @@ class PluginConfiguration
 
     public static function isNotProcessingUnpublishedPosts(): bool
     {
-        return get_option('coyote_skip_unpublished_enabled', true);
+        return !!get_option('coyote_skip_unpublished_enabled', true);
     }
 
     public static function getProcessedPostTypes(): array


### PR DESCRIPTION
Moved api endpoint to advanced settings. Added extra checks for get_option return values (with the separate sub-pages sometimes a get_option can return an empty string when a boolean is expected).