### PR TITLE
call WordPressPlugin::setupControllers() via plugins_loaded hook

### DIFF
--- a/php/WordPressPlugin.php
+++ b/php/WordPressPlugin.php
@@ -33,10 +33,13 @@ class WordPressPlugin
 
         WordPressActionsAndFilters::setupPluginActionsAndFilters($pluginFile);
 
-        self::setupControllers();
+		/*
+		 * setupControllers after plugins_loaded so wp-includes/pluggable.php is loaded
+		 */
+		add_action('plugins_loaded', [$this, 'setupControllers']);
     }
 
-    private static function setupControllers(): void
+    public static function setupControllers(): void
     {
         if (PluginConfiguration::userIsAdmin()) {
             (new SettingsController());


### PR DESCRIPTION
call WordPressPlugin::setupControllers() via plugins_loaded hook so wp-includes/pluggable.php is loaded

had to make setupControllers public, can't fully oversee if this has unwanted implications for the plugin (@jkva)